### PR TITLE
@cjheath Renamed DFU mode to Bootload mode, to make it clear that Bootload is not DFU. Fixed compile warning.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # paths to libraries
 MCULIB         ?= mculib
 OPENCM3_DIR    ?= libopencm3
-DFU_PORT       ?= /dev/ttyACM0
+BOOTLOAD_PORT       ?= /dev/ttyACM0
 
 # device config
 BOARDNAME       ?= board_v2_2
@@ -88,8 +88,8 @@ dist-clean: clean
 flash: binary.hex
 	./st-flash --reset --format ihex write binary.hex
 
-dfu: binary.bin
-	python3 dfu.py --file $< --serial $(DFU_PORT)
+bootload_firmware dfu: binary.bin
+	python3 bootload_firmware.py --file $< --serial $(BOOTLOAD_PORT)
 
 include $(OPENCM3_DIR)/mk/genlink-rules.mk
 include $(OPENCM3_DIR)/mk/gcc-rules.mk

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+## NanoVNA V2 Firmware
 
 This repository contains the source code to build the firmware for the NanoVNA V2 (S-A-A-2).
 
@@ -5,22 +6,25 @@ See https://nanorfe.com/nanovna-v2.html for more info.
 
 Developers chat room: https://discord.gg/DUH5Xk5
 
-Below is information for building the firmware on Linux.
+Below is information for building and uploading the firmware.
 
 ## Installing the compiler
 
-### Debian based systems
+The ARM GCC compiler is maintained by ARM, and is also available by other methods.
+
+### Debian Linux based systems
 
 On any recent Debian based installation:
 ``` 
 sudo apt install gcc-arm-none-eabi
 ```
 
-### Installing the upstream toolchain
+### Installing the upstream toolchain direct from ARM
 
 If you want to install the latest version of the gnu ARM toolchain:
 
-1. get the latest version from https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads . You can download it using your browser or a command line tool like `wget`:
+1. Get the latest version of the toolchain from https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads .
+You can download it using your browser or a command line tool like `wget`:
 ```
 wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2
 ```
@@ -36,27 +40,7 @@ sudo tar xvf -C /opt/toolchains gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.
 export PATH=/opt/toolchains/gcc-arm-none-eabi-9-2020-q2-update/bin:$PATH
 ```
 
-## Installing dependencies for the firmware upload tools
-
-The GD32F303 processor does not support the normal [USB DFU](https://www.usb.org/sites/default/files/DFU_1.1.pdf) mode. Instead, a serial bootloader program is installed. This serial tool was unfortunately named "dfu" even though it has no relationship to DFU. Please do not attempt to use a standard USB DFU tool.
-
-To install the bootloader on a new GD32F303, you will need to use an [ST-Link](https://www.st.com/en/development-tools/st-link-v2.html) device, of which many inexpensive clones are available. The [bootloader](bootloader/binary.bin) should be loaded at address 0x8000000, the start of the GD32F303 flash section.
-
-If you are using an ST-Link adapter, you should load the firmware binary at address 0x8004000. Some reports indicate that the NanoVNAv2 cannot be powered via the 3.2v supply from the ST-Link, but should be powered from its own battery.
-
-If you have an intact bootloader already installed in your NanoVNAv2, you have options to upload the firmware:
-
-- Using (NanoVNAv2-QT](https://github.com/nanovna-v2/NanoVNA-QT)
-
-- Using Python and the [dfu.py](dfu.py) script. You need Python version 3, and [pyserial](https://github.com/pyserial/pyserial)
-
-On a Debian based system, you can get pyserial using:
-
-```
-sudo apt install python3-serial
-```
-
-## Getting the source code
+## Downloading this source code
 
 The code is spread out over 3 repositories, 2 of which are submodules of the main NanoVNA-V2-firmware one:
 ```
@@ -78,46 +62,70 @@ Since Plus4 ECAL is no longer needed, and the extra RAM can be used to increase 
 - `board_v2_plus` for V2 Plus hardware
 - `board_v2_plus4` for V2 Plus4 hardware
 
-For Plus4, a different linker script needs to be used. The build command line for the Plus4 is:
+For Plus4, a different linker script and display driver needs to be used. The build command line for the Plus4 is:
 ```
 make BOARDNAME=board_v2_plus4 EXTRA_CFLAGS="-DSWEEP_POINTS_MAX=201 -DSAVEAREA_MAX=7 -DDISPLAY_ST7796" LDSCRIPT=./gd32f303cc_with_bootloader_plus4.ld
 ```
 
-The first time you build the firmware on a fresh repository, there is a libopencm3 bug that sometimes causes the linker script to be overwritten with a nonworking one. If the built firmware does not boot, try running:
+The first time you build the firmware on a fresh repository, there is a libopencm3 bug that sometimes causes the linker script to be overwritten with one that will not work. If the built firmware does not boot, try running the following commands, then rebuild:
 ```
-git reset --hard gd32f303cc_with_bootloader.ld
-git reset --hard gd32f303cc_with_bootloader_plus4.ld
-```
-And rebuilding.
-
-
-## Flashing the firmware
-There are two options to update the firmware when using the regular USB interface:
- - Use NanoVNA-QT
- - Command line
-For this to work the device must stay in the bootloader and enter _DFU mode_
-
-Another option is using a debugger using the debug pins.
-
-### Entering serial firmware update mode
-```
-Switch the device off
-Press and hold down the left button (the one closest to the Port 1 or the On/Off switch)
-Switch the device on (screen stays white), release the button
+git checkout -- gd32f303cc_with_bootloader.ld
+git checkout -- gd32f303cc_with_bootloader_plus4.ld
 ```
 
-On a *nix system, the current user probably needs to be part of the dialout group to allow access so the serial port.
+## To upload the firmware
+
+The GD32F303 processor does not support [USB DFU](https://www.usb.org/sites/default/files/DFU_1.1.pdf) mode like the STM32 chips do.
+Instead, a serial bootloader program is installed. Please do not attempt to use a standard USB DFU tool.
+
+The [bootloader](bootloader/binary.bin) should be loaded at address 0x8000000, the start of the GD32F303 flash section.
+To install the bootloader on a new GD32F303, you will need to use an [ST-Link](https://www.st.com/en/development-tools/st-link-v2.html) device, of which many inexpensive clones are available.
+Some reports indicate that the NanoVNAv2 cannot be powered via the 3.2v supply from the ST-Link, but should be powered from its own battery.
+
+The NanoVNA V2 firmware is installed at address 0x8004000.
+You can upload the firmware binary to that address using an ST-Link.
+
+If your device already has a working serial bootloader, you can upload the firmware without needing extra hardware.
+
+## Updating firmware using the serial bootloader
+
+If you have an intact bootloader already installed in your NanoVNAv2, there are several ways to update the firmware.
+
+You can update the firmware using (NanoVNAv2-QT](https://github.com/nanovna-v2/NanoVNA-QT). Restart your NanoVNA as described below and follow the instructions in NanoVNAv2-QT.
+
+Otherwise, you can update your firmware using Python and the [bootload_firmware.py](bootload_firmware.py) script.
+Ensure you have Python version 3, and install [pyserial](https://github.com/pyserial/pyserial).
+
+On a Debian based system, you can get pyserial using:
+
+```
+sudo apt install python3-serial
+```
+
+## Updating the firmware
+
+You must restart the device in BOOTLOAD mode:
+```
+Switch the device off.
+Press and hold down the left button (the one closest to the Port 1 or the On/Off switch).
+Switch the device on (screen stays white), release the button.
+```
+
+You will see a blank white screen. This indicates that it is waiting for new firmware.
+Check for the existence of the USB serial port device. This should be the device-special file /dev/ttyACM0
+On a *nix system, the current user probably needs to be part of the dialout group to allow access to ths device.
 
 Flashing can be done by running:
 ```
-python dfu.py -f binary.bin
-```
-On some systems you may need to invoke python3 instead:
-```
-python3 dfu.py -f binary.bin
+python bootload_firmware.py -f binary.bin
 ```
 
-Note that depending on your installation's *udev* rules, the new serial device might be seen as an Mobile Modem (3G/4G/etc) and it will not create the /dev/ttyACM0 port. 
-After a while the modem manager will give up and you can access the device.
-If this is too much of a burden, you need to add udev rules to block modem manager from doing so.
+On some systems you may need to explicitly invoke python3 instead:
+```
+python3 bootload_firmware.py -f binary.bin
+```
+
+Note that depending on your installation's *udev* rules, the new serial device initially appear as an Mobile Modem (3G/4G/etc)
+and it will not create the /dev/ttyACM0 port.  After a while the modem manager will give up and you can access the port.
+If this is too much of a burden, you can add udev rules to block modem manager from trying to control this port.
 

--- a/bootload_firmware.py
+++ b/bootload_firmware.py
@@ -62,8 +62,8 @@ def read_serialNumber(ser):
     sn = f"{sn[0]:08x}-{sn[1]:08x}-{sn[2]:08x}"
     return sn
 
-def detect_dfu(ser):
-    """returns true if device is in dfu mode"""
+def detect_bootloader_mode(ser):
+    """returns true if device is in bootloader mode"""
 
     # reset protocol to known state
     ser.write([0] * 8)
@@ -71,8 +71,8 @@ def detect_dfu(ser):
     # read registers 0xf1->0xf4
     # f0: device variant
     # f1: protocol version (01)
-    # f2: hardware revision (always 0 in dfu mode)
-    # f3: firmware major version (ff => dfu mode)
+    # f2: hardware revision (always 0 in bootloader mode)
+    # f3: firmware major version (ff => bootloader mode)
     # f4: firmware minor version (bootloader version)
 
     cmd = b"\x10\xf0\x10\xf1\x10\xf2\x10\xf3\x10\xf4"
@@ -80,7 +80,7 @@ def detect_dfu(ser):
     resp = ser.read(5)
 
     if resp and len(resp) == 5:
-        # firmware major version is always 0xff in dfu mode
+        # firmware major version is always 0xff in bootloader mode
         if resp[3] == 0xFF:
             return True
         print(f"Informations:")
@@ -185,10 +185,10 @@ def main():
         print(sn)
         exit(ret)
 
-    if not detect_dfu(ser):
-        print("Device not in DFU mode")
+    if not detect_bootloader_mode(ser):
+        print("Device not in Bootload mode")
         print(
-            "Please enter DFU mode through menu CONFIG -> DFU or hold down "
+            "Please enter Bootload mode through menu CONFIG -> BOOTLOAD or hold down "
             "the JOG LEFT button and power cycle the device."
         )
         exit(1)

--- a/bootloader/Makefile
+++ b/bootloader/Makefile
@@ -1,7 +1,7 @@
 MCULIB         ?= ../mculib
 DEVICE          = gd32f303cc
 OPENCM3_DIR    ?= ../libopencm3
-OBJS           += main.o ../common.o ../command_parser.o ../stream_fifo.o
+OBJS           += bootloader.o ../common.o ../command_parser.o ../stream_fifo.o
 OBJS           += $(MCULIB)/fastwiring.o $(MCULIB)/usbserial.o
 
 
@@ -27,7 +27,7 @@ flash: binary.hex
 	./st-flash --reset --format ihex write binary.hex
 
 factory_flash: binary.bin
-	# set magic value to enter dfu mode
+	# set magic value to enter bootloader mode
 	echo -n -e '\xbe\xba\x0b\xb0\xce\xfa\xef\xbe' | dd of=binary.bin bs=1024 seek=17
 	./st-flash --reset write binary.bin 0x08000000
 

--- a/common.hpp
+++ b/common.hpp
@@ -119,8 +119,8 @@ enum MeasurementMode {
     MEASURE_MODE_REFL_THRU_REFRENCE, //No ecal
 };
 
-constexpr uint32_t BOOTLOADER_DFU_MAGIC = 0xdeadbabe;
-static volatile uint32_t& bootloaderDFUIndicator = *(uint32_t*)(0x20000000 + 48*1024 - 4);
+constexpr uint32_t BOOTLOADER_BOOTLOAD_MAGIC = 0xdeadbabe;
+static volatile uint32_t& bootloaderBootloadIndicator = *(uint32_t*)(0x20000000 + 48*1024 - 4);
 
 
 

--- a/main.hpp
+++ b/main.hpp
@@ -48,7 +48,7 @@ namespace UIActions {
 
 	void printTouchCal();
 
-	void enterDFU();
+	void enterBootload();
 
 	void reconnectUSB();
 

--- a/main2.cpp
+++ b/main2.cpp
@@ -1481,7 +1481,7 @@ void debug_plot_markmap() {
 	plot_shadeCells = true;
 	draw_all_cells(true);
 
-	UIActions::enterDFU();
+	UIActions::enterBootload();
 	while(true);
 }
 
@@ -2133,11 +2133,11 @@ namespace UIActions {
 				(int)config.touch_cal[2], (int)config.touch_cal[3]);
 	}
 
-	void enterDFU() {
+	void enterBootload() {
 		// finish screen updates
 		lcd_spi_waitDMA();
 		// write magic value into ram (note: corrupts top of the stack)
-		bootloaderDFUIndicator = BOOTLOADER_DFU_MAGIC;
+		bootloaderBootloadIndicator = BOOTLOADER_BOOTLOAD_MAGIC;
 		// soft reset
 		SCB_AIRCR = SCB_AIRCR_VECTKEY | SCB_AIRCR_SYSRESETREQ;
 		while(true);

--- a/main2.cpp
+++ b/main2.cpp
@@ -88,7 +88,7 @@ static volatile bool lcdInhibit = false;
 
 float gainTable[RFSW_BBGAIN_MAX+1];
 
-__attribute__((packed))
+// __attribute__((packed))	// Sigh, cannot be packed because complexf is not packed
 struct usbDataPoint {
 	//VNAObservation value;
 	complexf S11, S21;
@@ -332,7 +332,7 @@ static void adf4350_powerup(void) {
 
 // automatically set IF frequency depending on rf frequency and board parameters
 static void updateIFrequency(freqHz_t txFreqHz) {
-	int avg = current_props._avg;
+//	int avg = current_props._avg;
 //	if(usbDataMode) avg = 1;
 	if(BOARD_REVISION >= 3) {
 		nvic_disable_irq(NVIC_TIM1_UP_IRQ);

--- a/ui.cpp
+++ b/ui.cpp
@@ -379,7 +379,7 @@ show_message(const char* title, const char* message, int fg, int bg)
 }
 
 void
-ui_enter_dfu(void)
+ui_enter_bootload(void)
 {
   uiDisableProcessing();
 
@@ -388,10 +388,10 @@ ui_enter_dfu(void)
   ili9341_set_background(DEFAULT_BG_COLOR);
   // leave a last message
   ili9341_clear_screen();
-  ili9341_drawstring("DFU: Device Firmware Update Mode", x, y += FONT_STR_HEIGHT);
-  ili9341_drawstring("To exit DFU mode, please reset device yourself.", x, y += FONT_STR_HEIGHT);
+  ili9341_drawstring("BOOTLOAD: Device Firmware Update Mode", x, y += FONT_STR_HEIGHT);
+  ili9341_drawstring("To exit Bootload mode, please reset device yourself.", x, y += FONT_STR_HEIGHT);
 
-  enterDFU();
+  enterBootload();
 }
 
 
@@ -524,11 +524,11 @@ static UI_FUNCTION_CALLBACK(menu_config_save_cb)
   menu_move_back(true);
 }
 
-static UI_FUNCTION_CALLBACK(menu_dfu_cb)
+static UI_FUNCTION_CALLBACK(menu_bootload_cb)
 {
   (void)item;
   (void)data;
-  ui_enter_dfu();
+  ui_enter_bootload();
 }
 
 static UI_FUNCTION_CALLBACK(menu_save_cb)
@@ -1139,8 +1139,8 @@ const menuitem_t menu_recall[] = {
   { MT_NONE, 0, NULL, NULL } // sentinel
 };
 
-const menuitem_t menu_dfu[] = {
-  { MT_CALLBACK, 0, "RESET AND\nENTER DFU", (const void *)menu_dfu_cb },
+const menuitem_t menu_bootload[] = {
+  { MT_CALLBACK, 0, "RESET AND\nENTER Bootload", (const void *)menu_bootload_cb },
   { MT_CANCEL, 0, S_LARROW"CANCEL", NULL },
   { MT_NONE, 0, NULL, NULL } // sentinel
 };
@@ -1151,7 +1151,7 @@ const menuitem_t menu_config[] = {
   { MT_CALLBACK, 0, "SAVE", (const void *)menu_config_save_cb },
   { MT_CALLBACK, 0, "VERSION", (const void *)menu_config_cb },
   { MT_CALLBACK, 0, "DMESG", (const void *)menu_config_cb },
-  { MT_SUBMENU, 0, S_RARROW"DFU", (const void *)menu_dfu },
+  { MT_SUBMENU, 0, S_RARROW"BOOTLOAD", (const void *)menu_bootload },
   { MT_CANCEL, 0, S_LARROW" BACK", NULL },
   { MT_NONE, 0, NULL, NULL } // sentinel
 };

--- a/ui.hpp
+++ b/ui.hpp
@@ -69,7 +69,7 @@ void touch_cal_exec(void);
 void touch_draw_test(void);
 void touch_start_watchdog(void);
 bool touch_position(int *x, int *y);
-void ui_enter_dfu(void);
+void ui_enter_bootload(void);
 
 void ui_mode_normal(void);
 void ui_mode_menu(void);


### PR DESCRIPTION
As discussed, I renamed DFU more throughout the code and filenames. Only the makefile "dfu" target remains as a duplicate.